### PR TITLE
update package.json to use gulp when running npm start dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Spencer Alger <spencer@spenceralger.com>",
   "scripts": {
     "setup": "[ -d node_modules ] || npm install; [ -d bower_components ] || bower install;",
-    "dev": "npm run setup && webpack-dev-server"
+    "dev": "npm run setup && gulp server"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
use gulp instead of webpack-dev-server, which throws command not found if not globally installed